### PR TITLE
Protect the log file from random writes by the client threads

### DIFF
--- a/Case 3/resultados.txt
+++ b/Case 3/resultados.txt
@@ -6,34 +6,21 @@ delegado 0: envio-OK-continuando.
 delegado 0: envio- certificado del servidor. continuando.
 delegado 0: recibio-OK-continuando.
 delegado 0: envio-llave K_SC al cliente. continuado.
-delegado 0: envio-4700-reto al cliente. continuando 
-delegado 0: recibio-4700-reto correcto. continuado.
-delegado 0: recibio-NjY2Ng==-continuando
-delegado 0: envio-0311-cifrado con K_SC. continuado.
+delegado 0: envio-7410-reto al cliente. continuando 
+delegado 0: recibio-7410-reto correcto. continuado.
+delegado 0: recibio-MTIzNA==-continuando
+delegado 0: envio-0337-cifrado con K_SC. continuado.
 delegado 0: recibio-OK-Terminando exitosamente.
-delegado 2: recibio-HOLA-continuando.
-delegado 2: recibio-ALGORITMOS:AES:RSA:HMACSHA1-continuando.
-delegado 2: envio-OK-continuando.
-delegado 2: recibio-certificado del cliente. continuando.
-delegado 2: envio-OK-continuando.
-delegado 2: envio- certificado del servidor. continuando.
-delegado 2: recibio-OK-continuando.
-delegado 2: envio-llave K_SC al cliente. continuado.
-delegado 2: envio-3890-reto al cliente. continuando 
-delegado 2: recibio-3890-reto correcto. continuado.
-delegado 2: recibio-NjU2NQ==-continuando
-delegado 2: envio-0311-cifrado con K_SC. continuado.
-delegado 2: recibio-OK-Terminando exitosamente.
-delegado 4: recibio-HOLA-continuando.
-delegado 4: recibio-ALGORITMOS:AES:RSA:HMACSHA1-continuando.
-delegado 4: envio-OK-continuando.
-delegado 4: recibio-certificado del cliente. continuando.
-delegado 4: envio-OK-continuando.
-delegado 4: envio- certificado del servidor. continuando.
-delegado 4: recibio-OK-continuando.
-delegado 4: envio-llave K_SC al cliente. continuado.
-delegado 4: envio-4210-reto al cliente. continuando 
-delegado 4: recibio-4210-reto correcto. continuado.
-delegado 4: recibio--continuando
-delegado 4: envio-0315-cifrado con K_SC. continuado.
-delegado 4: recibio-OK-Terminando exitosamente.
+delegado 1: recibio-HOLA-continuando.
+delegado 1: recibio-ALGORITMOS:AES:RSA:HMACSHA1-continuando.
+delegado 1: envio-OK-continuando.
+delegado 1: recibio-certificado del cliente. continuando.
+delegado 1: envio-OK-continuando.
+delegado 1: envio- certificado del servidor. continuando.
+delegado 1: recibio-OK-continuando.
+delegado 1: envio-llave K_SC al cliente. continuado.
+delegado 1: envio-9670-reto al cliente. continuando 
+delegado 1: recibio-9670-reto correcto. continuado.
+delegado 1: recibio-NzYyMzEz-continuando
+delegado 1: envio-0337-cifrado con K_SC. continuado.
+delegado 1: recibio-OK-Terminando exitosamente.

--- a/Case 3/src/communication_protocol/server/D.java
+++ b/Case 3/src/communication_protocol/server/D.java
@@ -73,7 +73,7 @@ public class D extends Thread {
 	 * - Debe conservar el metodo .
 	 * - Es el Ãºnico metodo permitido para escribir en el log.
 	 */
-	private void escribirMensaje(String pCadena) {
+	private synchronized void escribirMensaje(String pCadena) {
 
 		try {
 			FileWriter fw = new FileWriter(file,true);


### PR DESCRIPTION
This adds write protection from threads by using a synchronized method modifier in the `escribirMensaje` method. By using this, only one thread can write to the file at a time, thus, displaying the information in blocks depending on the delegated client and the order in which the thread pool serves the tasks. 